### PR TITLE
Implement memory size warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added a features document under `docs/`.
 - Established this changelog.
 - Updated the feature list with status markers for each entry.
+- Implemented browser-memory check with size warnings for large PDFs.
 
 ## [0.1.0] - 2025-05-18
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,7 +2,7 @@
 This file lists potential features along with their current implementation status. See [roadmap.md](roadmap.md) for the planned order of development.
 
 - [x] **Client-side PDF upload** – File input works in-browser (drag-and-drop not implemented)
-- [ ] **Browser-memory check & size advice** – Not implemented
+- [x] **Browser-memory check & size advice** – Warns about large files
 - [ ] **Upload progress bar** – Not implemented
 - [x] **TOC parsing** – Read the PDF outline to build the document hierarchy
 - [ ] **Collapsible TOC tree view** – Not implemented

--- a/index.html
+++ b/index.html
@@ -35,6 +35,21 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.9.179/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
     <script>
+        function warnIfLargePDF(file) {
+            const progress = document.getElementById('progress');
+            progress.textContent = '';
+            if (!file) return;
+            const memGB = navigator.deviceMemory || 4;
+            const limit = memGB * 1024 * 1024 * 1024 * 0.25;
+            if (file.size > limit) {
+                progress.textContent = 'Warning: large file may exceed available memory. Consider splitting the PDF before upload.';
+            }
+        }
+
+        document.getElementById('pdfFile').addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            warnIfLargePDF(file);
+        });
         async function readOutline(pdf) {
             // Use PDF.js to read the outline/table of contents
             const pdfData = new Uint8Array(await pdf.arrayBuffer());
@@ -92,6 +107,7 @@
             outputDiv.innerHTML = '';
             if (!fileInput.files.length) return;
             const file = fileInput.files[0];
+            warnIfLargePDF(file);
             const outline = await readOutline(file);
             if (!outline.length) {
                 outputDiv.textContent = 'No outline found.';


### PR DESCRIPTION
## Summary
- warn when PDF is larger than available memory (estimates using `navigator.deviceMemory`)
- update feature list to mark memory check as implemented
- note new feature in changelog

## Testing
- `git status --short`