### PR TITLE
Fix extraction to use page indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Established this changelog.
 - Updated the feature list with status markers for each entry.
 - Implemented browser-memory check with size warnings for large PDFs.
+- Fixed page range detection for per-section extraction.
 
 ## [0.1.0] - 2025-05-18
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ This file lists potential features along with their current implementation statu
 - [ ] **Upload progress bar** – Not implemented
 - [x] **TOC parsing** – Read the PDF outline to build the document hierarchy
 - [ ] **Collapsible TOC tree view** – Not implemented
-- [x] **Per-section "Extract" action** – Export a single chosen section
+- [x] **Per-section "Extract" action** – Export a single chosen section (page range calculation fixed)
 - [ ] **Multi-select / bulk selection** – Not implemented
 - [ ] **Export format choice** – UI offers PDF or text, but only PDF output is implemented
 - [ ] **Full-document "iterate all" option** – Not implemented

--- a/index.html
+++ b/index.html
@@ -50,13 +50,45 @@
             const file = e.target.files[0];
             warnIfLargePDF(file);
         });
+        let pdfjsDoc = null;
+        async function resolveDest(doc, dest) {
+            if (typeof dest === 'string') {
+                dest = await doc.getDestination(dest);
+            }
+            return dest || null;
+        }
+
+        async function annotateOutline(doc, items, flat) {
+            for (const it of items) {
+                const resolved = it.dest ? await resolveDest(doc, it.dest) : null;
+                if (resolved) {
+                    try {
+                        it.pageIndex = await doc.getPageIndex(resolved[0]);
+                    } catch (e) {
+                        it.pageIndex = null;
+                    }
+                }
+                if (it.items && it.items.length) {
+                    await annotateOutline(doc, it.items, flat);
+                }
+                flat.push(it);
+            }
+        }
+
         async function readOutline(pdf) {
-            // Use PDF.js to read the outline/table of contents
             const pdfData = new Uint8Array(await pdf.arrayBuffer());
             const loadingTask = pdfjsLib.getDocument({ data: pdfData });
             const doc = await loadingTask.promise;
-            const outline = await doc.getOutline();
-            return outline || [];
+            pdfjsDoc = doc;
+            const outline = await doc.getOutline() || [];
+            const flat = [];
+            await annotateOutline(doc, outline, flat);
+            flat.sort((a, b) => (a.pageIndex ?? Infinity) - (b.pageIndex ?? Infinity));
+            for (let i = 0; i < flat.length; i++) {
+                const next = flat[i + 1];
+                flat[i].endPageIndex = next && next.pageIndex != null ? next.pageIndex : doc.numPages;
+            }
+            return outline;
         }
 
         function displayOutline(outline, container, prefix = '') {
@@ -65,7 +97,7 @@
                 const li = document.createElement('li');
                 const title = item.title || '<no title>';
                 li.textContent = prefix + title;
-                if (item.dest) {
+                if (item.pageIndex != null) {
                     const btn = document.createElement('button');
                     btn.textContent = 'Extract';
                     btn.onclick = () => extractSection(item);
@@ -86,10 +118,10 @@
             const file = fileInput.files[0];
             const arrayBuffer = await file.arrayBuffer();
             const pdfDoc = await PDFLib.PDFDocument.load(arrayBuffer);
-            const pageIndex = (item.dest[0].num || 0); // TODO: verify index resolution
-            const nextPage = item.next ? (item.next.dest[0].num || pdfDoc.getPageCount()) : pdfDoc.getPageCount();
+            const start = item.pageIndex || 0;
+            const end = item.endPageIndex || pdfDoc.getPageCount();
             const newDoc = await PDFLib.PDFDocument.create();
-            for (let i = pageIndex; i < nextPage; i++) {
+            for (let i = start; i < end; i++) {
                 const [copied] = await newDoc.copyPages(pdfDoc, [i]);
                 newDoc.addPage(copied);
             }


### PR DESCRIPTION
## Summary
- compute page indices when reading PDF outline
- use calculated page range for per-section extraction
- document change in changelog and features

## Testing
- `git status --short`