### PR TITLE
Fix script to set PDF.js worker path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Fixed page range detection for per-section extraction.
 - Added text extraction output for individual sections.
 - Added automatic iteration over all sections with optional ZIP export.
+- Fixed PDF.js configuration to load the worker script correctly.
 
 ## [0.1.0] - 2025-05-18
 ### Added

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script>
+        pdfjsLib.GlobalWorkerOptions.workerSrc =
+            `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
+
         function warnIfLargePDF(file) {
             const progress = document.getElementById('progress');
             progress.textContent = '';


### PR DESCRIPTION
## Summary
- configure PDF.js worker source so outline reading works reliably
- document the worker fix in the changelog

## Testing
- `git status --short`